### PR TITLE
Update metadata address errors

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,7 +2,6 @@
   "orgName": "ADA Wallet SO",
   "edition": "developer",
   "features": [
-    "Slack"
   ],
   "settings": {
     "lightningExperienceSettings": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -16,7 +16,7 @@
     }
   ],
   "name": "Ada Wallet for Salesforce",
-  "namespace": "mukn_web3enable",
+  "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "63.0",
   "packageAliases": {


### PR DESCRIPTION
Update metadata to to fix an error that was returned when using the `sf org create scratch -f ./config/project-scratch-def.json -a dev -d -y 30` command to create a scratch org.